### PR TITLE
feat: Update PWA and social media icons to placeholder-image.png

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/img/company-logo-1.png" />
     <link rel="shortcut icon" type="image/png" href="/favicon.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/img/company-logo-1.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/img/placeholder-image.png" />
     <link rel="manifest" href="/site.webmanifest" />
 
     <!-- Open Graph / Facebook -->
@@ -33,7 +33,7 @@
       property="og:description"
       content="Transform your feedlot operations with our AI-driven livestock management solutions featuring Cow Nose ID technology and continuous monitoring."
     />
-    <meta property="og:image" content="/img/company-logo-1.png" />
+    <meta property="og:image" content="/img/placeholder-image.png" />
     <meta property="og:url" content="https://livestock-tech.vercel.app" />
     <meta property="og:site_name" content="Livestock Technologies" />
 
@@ -47,7 +47,7 @@
       name="twitter:description"
       content="Transform your feedlot operations with our AI-driven livestock management solutions featuring Cow Nose ID technology and continuous monitoring."
     />
-    <meta name="twitter:image" content="/img/company-logo-1.png" />
+    <meta name="twitter:image" content="/img/placeholder-image.png" />
     <style>
       @import url("https://fonts.googleapis.com/css?family=Heebo:var(--heading-tagline-font-weight),var(--text-regular-medium-font-weight),var(--text-regular-normal-font-weight),var(--text-regular-link-font-weight),var(--text-small-semi-bold-font-weight),var(--text-small-link-font-weight),var(--text-medium-normal-font-weight),var(--text-small-normal-font-weight)|Archivo:var(--heading-h2-font-weight),var(--heading-h3-font-weight),var(--heading-h5-font-weight),var(--heading-h6-font-weight),var(--heading-h1-font-weight),var(--heading-h4-font-weight)");
     </style>

--- a/static/site.webmanifest
+++ b/static/site.webmanifest
@@ -9,6 +9,18 @@
   "orientation": "portrait-primary",
   "icons": [
     {
+      "src": "/img/placeholder-image.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/img/placeholder-image.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
       "src": "/img/company-logo-1.png",
       "sizes": "192x192",
       "type": "image/png",


### PR DESCRIPTION
This change updates the web app manifest and relevant meta tags in index.html to use `placeholder-image.png` as the primary icon.

Specifically:
- Added `placeholder-image.png` to the `icons` array in `static/site.webmanifest` with sizes 192x192 and 512x512.
- Updated `index.html` to use `/img/placeholder-image.png` for:
    - `apple-touch-icon`
    - `og:image` (Open Graph)
    - `twitter:image` (Twitter Card)

This ensures that `placeholder-image.png` is used when the PWA is downloaded to a phone and when the site is shared on social media.